### PR TITLE
Update sponsors page history and add 2026 sponsor note

### DIFF
--- a/sponsors.md
+++ b/sponsors.md
@@ -128,13 +128,13 @@ Please be patient with me as I'm currently transitioning to Dvorak 💜
 
 ## 11 Apr 2026
 
-I work full time on nonprofit financial infrastructure, public market research, and free investor education.
+I work full time on nonprofit financial infrastructure, public market research, and free investor protections.
 
 Over the last several years, I have intentionally moved away from the easier path of private trading, closed research, and conventional finance work. I care much more about building public systems that help ordinary people save, invest, and retire without so many extractive middlemen standing between them and the assets they actually own.
 
 Most of that work lives across my public repositories, especially this one and [`free-markets`](https://github.com/JFWooten4/free-markets). The throughline is consistent: better market structure, clearer ownership, transparent governance, less bureaucracy, and financial tools that serve workers, savers, and retirees instead of quietly siphoning value upward through centralized institutions.
 
-That is why I keep framing this as nonprofit work. I am not trying to build a closed system that enriches a small class of managers. I want common infrastructure, accountable transparency, and public-facing work-products that can outlast me. TAD3, the surrounding policy work, the DAO ideas, the public comments, and the educational materials all fit within that same mission.
+That is why I keep framing this as nonprofit work. I am not trying to build a closed system that enriches a small class of managers. I want common infrastructure, accountable transparency, and public-facing work-products that can outlast me. TAD3, the surrounding policy work, the DAO ideas, the public comments, and the documentation materials all fit within that same mission.
 
 Recent writing in `free-markets` has made that shift even clearer for me: I am less interested in optimizing for short-term trading gains than in improving the judgment, infrastructure, and governance needed for better long-run allocation. If legacy finance is organized around bureaucracy and rent extraction, I want to keep pushing toward systems that better protect real savings and pensions.
 
@@ -148,5 +148,5 @@ If this mission resonates with you, sponsorship helps fund:
 
 - TAD3 and related market-structure development;
 - nonprofit and DAO-oriented governance research;
-- free educational writing, public comments, and open documentation; plus
+- free philosophical writing, public comments, and open documentation; plus
 - long-run infrastructure work aimed at better savings and retirements for masses of people!

--- a/sponsors.md
+++ b/sponsors.md
@@ -124,3 +124,29 @@ I work on nonprofit financial infrastructure to help masses of people build real
 Please be patient with me as I'm currently transitioning to Dvorak 💜
 
 ### [Past Work](https://github.com/users/JFWooten4/projects/1/views/1?filterQuery=-status%3A%22Pending+%F0%9F%92%9C%22%2C%22%F0%9F%9A%80+Critical+Mission+%F0%9F%8C%8C%22%2C%22Backlogged+%28High%29+%F0%9F%8E%AF%22%2C%22Backlogged+%28Medium%29+%F0%9F%A7%A0%22%2C%22Backlogged+%28Low%29+%F0%9F%A4%9D%22%2C%22Awaiting+Response%22%2C%22Ideas+%F0%9F%92%A1%22)
+
+
+## 11 Apr 2026
+
+I work full time on nonprofit financial infrastructure, public market research, and free investor education.
+
+Over the last several years, I have intentionally moved away from the easier path of private trading, closed research, and conventional finance work. I care much more about building public systems that help ordinary people save, invest, and retire without so many extractive middlemen standing between them and the assets they actually own.
+
+Most of that work lives across my public repositories, especially this one and [`free-markets`](https://github.com/JFWooten4/free-markets). The throughline is consistent: better market structure, clearer ownership, transparent governance, less bureaucracy, and financial tools that serve workers, savers, and retirees instead of quietly siphoning value upward through centralized institutions.
+
+That is why I keep framing this as nonprofit work. I am not trying to build a closed system that enriches a small class of managers. I want common infrastructure, accountable transparency, and public-facing work-products that can outlast me. TAD3, the surrounding policy work, the DAO ideas, the public comments, and the educational materials all fit within that same mission.
+
+Recent writing in `free-markets` has made that shift even clearer for me: I am less interested in optimizing for short-term trading gains than in improving the judgment, infrastructure, and governance needed for better long-run allocation. If legacy finance is organized around bureaucracy and rent extraction, I want to keep pushing toward systems that better protect real savings and pensions.
+
+If you support this work, you are helping me keep it public, independent, and substance-first rather than steering toward ads, paywalls, promotional deals, or traditional equity incentives. Your support helps fund the time required to write, code, research, publish, and coordinate all of this in the open.
+
+### [Working Agenda](https://github.com/users/JFWooten4/projects/1)
+
+If you want the best live view of what I am actively building, researching, and trying to ship next, start there.
+
+If this mission resonates with you, sponsorship helps fund:
+
+- TAD3 and related market-structure development
+- nonprofit and DAO-oriented governance research
+- free educational writing, public comments, and open documentation
+- long-run infrastructure work aimed at better savings and retirements for ordinary people

--- a/sponsors.md
+++ b/sponsors.md
@@ -132,11 +132,11 @@ I work full time on nonprofit financial infrastructure, public market research, 
 
 Over the last five years, I have intentionally moved away from the easier path of private trading, closed development, and centralized finance work. I care much more about building public systems that help ordinary people save, invest, and retire without so many extractive middlemen standing between them and the assets they actually own.
 
-Most of that work lives across my public repositories and organizations. The throughline is consistent: better market structure, clearer ownership, transparent governance, less bureaucracy, and financial tools that serve workers, savers, and retirees instead of quietly siphoning value upward through centralized institutions.
+Most of that work lives across my public repositories and organizations. The throughline is consistent: new market structure, clear ownership, and transparent governance. We get to build financial tools that siphon value away from centralized institutions and back to the people.
 
-That is why I keep framing this as nonprofit work and formed the 501(c)(3). I am not trying to build a closed system that enriches a small class of managers. I want common infrastructure, accountable transparency, and public-facing work-products that can outlast me. TAD3, the surrounding policy work, the DAO ideas, the public comments, and the documentation materials all fit within that same mission.
+That is why we formed the 501(c)(3) to keep this as nonprofit work. I am not trying to build a closed system that enriches a small class of managers. I want common infrastructure, accountable transparency, and public-facing work-products that can outlast me. TAD3, the surrounding policy work, the DAO ideas, the public comments, and the documentation materials all fit within that same mission.
 
-If you support this work, you are helping me keep it public, independent, and substance-first rather than steering toward ads, paywalls, promotional deals, or traditional equity incentives. Your support helps fund the time required to write, code, research, publish, and coordinate all of this in the open.
+If you support this work, you are helping me keep it public, independent, and substance-first rather than steering toward CEXs, extraction, or gatekeeping. Your support helps fund the time required to write, code, and coordinate all of this in the open.
 
 ### [Working Agenda](https://github.com/users/JFWooten4/projects/1)
 

--- a/sponsors.md
+++ b/sponsors.md
@@ -132,11 +132,11 @@ I work full time on nonprofit financial infrastructure, public market research, 
 
 Over the last several years, I have intentionally moved away from the easier path of private trading, closed research, and conventional finance work. I care much more about building public systems that help ordinary people save, invest, and retire without so many extractive middlemen standing between them and the assets they actually own.
 
-Most of that work lives across my public repositories, especially this one and [`free-markets`](https://github.com/JFWooten4/free-markets). The throughline is consistent: better market structure, clearer ownership, transparent governance, less bureaucracy, and financial tools that serve workers, savers, and retirees instead of quietly siphoning value upward through centralized institutions.
+Most of that work lives across my public repositories and organizations. The throughline is consistent: better market structure, clearer ownership, transparent governance, less bureaucracy, and financial tools that serve workers, savers, and retirees instead of quietly siphoning value upward through centralized institutions.
 
 That is why I keep framing this as nonprofit work. I am not trying to build a closed system that enriches a small class of managers. I want common infrastructure, accountable transparency, and public-facing work-products that can outlast me. TAD3, the surrounding policy work, the DAO ideas, the public comments, and the documentation materials all fit within that same mission.
 
-Recent writing in `free-markets` has made that shift even clearer for me: I am less interested in optimizing for short-term trading gains than in improving the judgment, infrastructure, and governance needed for better long-run allocation. If legacy finance is organized around bureaucracy and rent extraction, I want to keep pushing toward systems that better protect real savings and pensions.
+I am less interested in optimizing for short-term trading gains than in improving the judgment, infrastructure, and governance needed for better long-run allocation. If legacy finance is organized around bureaucracy and rent extraction, I want to keep pushing toward systems that better protect real investment opportunities and pensions.
 
 If you support this work, you are helping me keep it public, independent, and substance-first rather than steering toward ads, paywalls, promotional deals, or traditional equity incentives. Your support helps fund the time required to write, code, research, publish, and coordinate all of this in the open.
 

--- a/sponsors.md
+++ b/sponsors.md
@@ -128,15 +128,13 @@ Please be patient with me as I'm currently transitioning to Dvorak 💜
 
 ## 11 Apr 2026
 
-I work full time on nonprofit financial infrastructure, public market research, and free investor protections.
+I work full time on nonprofit financial infrastructure, public market research, and permissionless investor protections. I am less interested in optimizing for short-term trading gains than in improving the judgment, infrastructure, and governance needed for long-run allocation. If legacy finance is organized around bureaucracy and rent extraction, I want to keep pushing toward systems that protects real investment opportunities, innovation, and pensions.
 
-Over the last five years, I have intentionally moved away from the easier path of private trading, closed development, and conventional finance work. I care much more about building public systems that help ordinary people save, invest, and retire without so many extractive middlemen standing between them and the assets they actually own.
+Over the last five years, I have intentionally moved away from the easier path of private trading, closed development, and centralized finance work. I care much more about building public systems that help ordinary people save, invest, and retire without so many extractive middlemen standing between them and the assets they actually own.
 
 Most of that work lives across my public repositories and organizations. The throughline is consistent: better market structure, clearer ownership, transparent governance, less bureaucracy, and financial tools that serve workers, savers, and retirees instead of quietly siphoning value upward through centralized institutions.
 
 That is why I keep framing this as nonprofit work and formed the 501(c)(3). I am not trying to build a closed system that enriches a small class of managers. I want common infrastructure, accountable transparency, and public-facing work-products that can outlast me. TAD3, the surrounding policy work, the DAO ideas, the public comments, and the documentation materials all fit within that same mission.
-
-I am less interested in optimizing for short-term trading gains than in improving the judgment, infrastructure, and governance needed for better long-run allocation. If legacy finance is organized around bureaucracy and rent extraction, I want to keep pushing toward systems that better protect real investment opportunities and pensions.
 
 If you support this work, you are helping me keep it public, independent, and substance-first rather than steering toward ads, paywalls, promotional deals, or traditional equity incentives. Your support helps fund the time required to write, code, research, publish, and coordinate all of this in the open.
 

--- a/sponsors.md
+++ b/sponsors.md
@@ -130,7 +130,7 @@ Please be patient with me as I'm currently transitioning to Dvorak 💜
 
 I work full time on nonprofit financial infrastructure, public market research, and permissionless investor protections. I am less interested in optimizing for short-term trading gains than in improving the judgment, infrastructure, and governance needed for long-run allocation. If legacy finance is organized around bureaucracy and rent extraction, I want to keep pushing toward systems that protects real investment opportunities, innovation, and pensions.
 
-Over the last five years, I have intentionally moved away from the easier path of private trading, closed development, and centralized finance work. I care much more about building public systems that help ordinary people save, invest, and retire without so many extractive middlemen standing between them and the assets they actually own.
+Over the last many years, I have intentionally moved away from the easier path of private trading, closed development, and centralized finance work. I care much more about building public systems that help ordinary people save, invest, and retire without so many extractive middlemen standing between them and the assets they actually own.
 
 Most of that work lives across my public repositories and organizations. The throughline is consistent: new market structure, clear ownership, and transparent governance. We get to build financial tools that siphon value away from centralized institutions and back to the people.
 
@@ -147,4 +147,4 @@ If this mission resonates with you, sponsorship helps fund:
 - TAD3 and related market-structure development;
 - nonprofit and DAO-oriented governance research;
 - free philosophical writing, public comments, and open documentation; plus
-- long-run infrastructure work aimed at better savings and retirements for masses of people!
+- stock infrastructure work building savings and retirements for masses of people!

--- a/sponsors.md
+++ b/sponsors.md
@@ -146,7 +146,7 @@ If you want the best live view of what I am actively building, researching, and 
 
 If this mission resonates with you, sponsorship helps fund:
 
-- TAD3 and related market-structure development
-- nonprofit and DAO-oriented governance research
-- free educational writing, public comments, and open documentation
-- long-run infrastructure work aimed at better savings and retirements for ordinary people
+- TAD3 and related market-structure development;
+- nonprofit and DAO-oriented governance research;
+- free educational writing, public comments, and open documentation; plus
+- long-run infrastructure work aimed at better savings and retirements for masses of people!

--- a/sponsors.md
+++ b/sponsors.md
@@ -130,11 +130,11 @@ Please be patient with me as I'm currently transitioning to Dvorak 💜
 
 I work full time on nonprofit financial infrastructure, public market research, and free investor protections.
 
-Over the last several years, I have intentionally moved away from the easier path of private trading, closed research, and conventional finance work. I care much more about building public systems that help ordinary people save, invest, and retire without so many extractive middlemen standing between them and the assets they actually own.
+Over the last five years, I have intentionally moved away from the easier path of private trading, closed development, and conventional finance work. I care much more about building public systems that help ordinary people save, invest, and retire without so many extractive middlemen standing between them and the assets they actually own.
 
 Most of that work lives across my public repositories and organizations. The throughline is consistent: better market structure, clearer ownership, transparent governance, less bureaucracy, and financial tools that serve workers, savers, and retirees instead of quietly siphoning value upward through centralized institutions.
 
-That is why I keep framing this as nonprofit work. I am not trying to build a closed system that enriches a small class of managers. I want common infrastructure, accountable transparency, and public-facing work-products that can outlast me. TAD3, the surrounding policy work, the DAO ideas, the public comments, and the documentation materials all fit within that same mission.
+That is why I keep framing this as nonprofit work and formed the 501(c)(3). I am not trying to build a closed system that enriches a small class of managers. I want common infrastructure, accountable transparency, and public-facing work-products that can outlast me. TAD3, the surrounding policy work, the DAO ideas, the public comments, and the documentation materials all fit within that same mission.
 
 I am less interested in optimizing for short-term trading gains than in improving the judgment, infrastructure, and governance needed for better long-run allocation. If legacy finance is organized around bureaucracy and rent extraction, I want to keep pushing toward systems that better protect real investment opportunities and pensions.
 

--- a/sponsors.md
+++ b/sponsors.md
@@ -4,40 +4,40 @@ History of https://wooten.link/sponsor
 
 ```
 
-## 4 Mar 2024
+## [4 Mar 2024](https://discord.com/channels/1102309240145707049/1120679402754281575/1214286885871026208)
 
-Hi @everyone,
-I haven't heard back from the grant yet, but hopefully that will support our hiring of devs.
-
-The plan since early on (we were first denied for 50k at the end of 2022) was to use those community funds to build out the frontend based on the (continuing) years of work I've put into the backend. Long-term, I'd love to open-source it so that we can have common global settlement. :handshake:
-
-Common global settlement, imo, redefines how we approach capitalism. It's been an enlightening journey taking TAD3 from an idea to proper documentation/SEC review. However, all this research and development has been effectively self-funded, per our startup post.
-
-I'm at a crossroads. :railway_track:
-
-Recently upon reflecting I came to the conclusion that raising money was a good next step for BT.
-
-We're at the point where we really need development help to flesh out the interface with TAD3.
-As I've said in the Discord, I'm starkly against raising and will not sell traditional equity.
-If I was to go down that rabbit hole, I would sell capped-profit contracts like OpenAI. :money_with_wings:
-
-We can't let TAD3, or whatever we all ultimately use (nothing similar I know of) fall victim to the same rent-seeking incentives plaguing DTCC. :earth_africa:
-Just last week dozens of industry experts expressed bafflement at how slow stocks clear when Amazon delivers in an hour, by one Seattle man's account.
-
-This is something important, and that's why I was so excited the day I learned about the WhyDRS community and movement.
-
-I actually couldn't tear myself away from the computer long enough to eat a meal the first day I found the WhyDRS site.
-After a minor passing out, I still could not believe an active group of other people understood and cared about these massive hidden market problems. :star2:
-More specifically, I was so overcome with fulfillment that I proposed to my girlfriend (of 3 years, similar to BT). (she said yes)
-
-I am building this the right way, or not at all. :100:
-
-That's why I'm setting up a GH sponsor page to keep my work alive, community-focused, and nonprofit.
-If you support democratizing capitalism, freeing our markets from Wall St, and decentralized independent money management, please learn more at https://sponsor.jfwooten4.com/
-
-Either way, this community is truly incredible and will always have my ongoing support. :purple_heart:
-
-[<img width="100" alt="reactions" src="https://github.com/user-attachments/assets/53327d81-ccf5-49c6-baf3-8c1e06886d06">](https://discord.com/channels/1102309240145707049/1120679402754281575/1214286885871026208)
+> Hi @everyone,
+> I haven't heard back from the grant yet, but hopefully that will support our hiring of devs.
+>
+> The plan since early on (we were first denied for 50k at the end of 2022) was to use those community funds to build out the frontend based on the (continuing) years of work I've put into the backend. Long-term, I'd love to open-source it so that we can have common global settlement. :handshake:
+>
+> Common global settlement, imo, redefines how we approach capitalism. It's been an enlightening journey taking TAD3 from an idea to proper documentation/SEC review. However, all this research and development has been effectively self-funded, per our startup post.
+>
+> I'm at a crossroads. :railway_track:
+>
+> Recently upon reflecting I came to the conclusion that raising money was a good next step for BT.
+>
+> We're at the point where we really need development help to flesh out the interface with TAD3.
+> As I've said in the Discord, I'm starkly against raising and will not sell traditional equity.
+> If I was to go down that rabbit hole, I would sell capped-profit contracts like OpenAI. :money_with_wings:
+>
+> We can't let TAD3, or whatever we all ultimately use (nothing similar I know of) fall victim to the same rent-seeking incentives plaguing DTCC. :earth_africa:
+> Just last week dozens of industry experts expressed bafflement at how slow stocks clear when Amazon delivers in an hour, by one Seattle man's account.
+>
+> This is something important, and that's why I was so excited the day I learned about the WhyDRS community and movement.
+>
+> I actually couldn't tear myself away from the computer long enough to eat a meal the first day I found the WhyDRS site.
+> After a minor passing out, I still could not believe an active group of other people understood and cared about these massive hidden market problems. :star2:
+> More specifically, I was so overcome with fulfillment that I proposed to my girlfriend (of 3 years, similar to BT). (she said yes)
+>
+> I am building this the right way, or not at all. :100:
+>
+> That's why I'm setting up a GH sponsor page to keep my work alive, community-focused, and nonprofit.
+> If you support democratizing capitalism, freeing our markets from Wall St, and decentralized independent money management, please learn more at https://sponsor.jfwooten4.com/
+>
+> Either way, this community is truly incredible and will always have my ongoing support. :purple_heart:
+>
+> [<img width="100" alt="reactions" src="https://github.com/user-attachments/assets/53327d81-ccf5-49c6-baf3-8c1e06886d06">](https://discord.com/channels/1102309240145707049/1120679402754281575/1214286885871026208)
 
 
 ## 13 Jun 2024


### PR DESCRIPTION
## Summary
- convert the 4 Mar 2024 sponsor update into a linked blockquote section
- add a new 11 Apr 2026 sponsor update describing current mission, agenda, and sponsorship goals
- tighten the sponsors page history around clearer public-facing fundraising context

## Testing
- not run (content-only markdown changes)